### PR TITLE
MNT: Use Git rev for build source

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -7,13 +7,10 @@ package:
   version: ${{ version }}
 
 source:
-  # Windows can't seem to use git option
-  # git: https://github.com/DavidMStraub/rundec-python.git
+  git: https://github.com/DavidMStraub/rundec-python.git
   # tag: ${{ version }}
   # Use exact commit as no tags for v0.5.1 or later (yet)
-  # rev: "1b3006f03098ef4c6d44200ef643fede9c426cfe"
-  url: https://github.com/DavidMStraub/rundec-python/archive/1b3006f03098ef4c6d44200ef643fede9c426cfe.tar.gz
-  sha256: 2728d6989522fcff44ba488fb824bda5c74da6aff2d68e4c359769cf43c7cf4e
+  rev: "1b3006f03098ef4c6d44200ef643fede9c426cfe"
   patches: add-pyproject-toml-for-build-system.patch
 
 build:


### PR DESCRIPTION
* Use rev to pin to the commit that corresponds to the version as no tags exist.
   - c.f. https://rattler.build/v0.42.1/reference/recipe_file/#source-from-git

This PR is being opened to demonstrate the failure mode on Windows and might not get merged.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
